### PR TITLE
Add prefixes to lru redis cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,6 @@ jobs:
           npm install -g zx
           make redis
           cargo run &
-          make pip_test
+          make scenario_test
           kill %1
           make redis_stop

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ run:
 	cargo run
 
 test:
+	docker stop redis_test || return 0
 	docker run $(REDIS_OPTS) --name redis_test -d -p 3001:6379 --rm redis /conf/redis.conf
 	cargo test
 	docker stop redis_test
@@ -55,7 +56,7 @@ clean:
 	docker stop redis_dev || return 0
 	docker stop redis_test || return 0
 
-pip_test:
+scenario_test:
 	zx ./scripts/pip_test.mjs
 	zx ./scripts/conda_test.mjs
 	zx ./scripts/concurrent.mjs

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ fn create_cache_from_rule(
     redis_client: Option<redis::Client>,
 ) -> Result<Arc<dyn CachePolicy>> {
     let policy_ident = rule.policy.clone();
-    for p in policies {
+    for (idx, p) in policies.iter().enumerate() {
         if p.name == policy_ident {
             let policy_type = p.typ;
             match policy_type {
@@ -71,6 +71,7 @@ fn create_cache_from_rule(
                         p.path.as_ref().unwrap(),
                         p.size.unwrap_or(0),
                         redis_client.unwrap(),
+                        &format!("lru_rule{}", idx),
                     )));
                 }
                 PolicyType::Ttl => {


### PR DESCRIPTION
Different `LruRedisCache `instances are now isolated.
Close #18 

Also fixed wrong size update in key update.
Close #17 